### PR TITLE
Abbreviate resource name prefix to address #28

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 _out/
-runai-preinstall-diagnostics.txt
+runai-diagnostics.txt
 .idea/

--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ Usage of ./preinstall-diagnostics-darwin-arm64:
   -image string
     	Diagnostics image to use (for air-gapped environments) (default "gcr.io/run-ai-lab/preinstall-diagnostics:v2.16.18")
   -image-pull-secret string
-    	Secret name (within the 'runai-preinstall-diagnostics' namespace) that contains container-registry credentials
+    	Secret name (within the 'runai-diagnostics' namespace) that contains container-registry credentials
   -kubeconfig string
     	Paths to a kubeconfig. Only required if out-of-cluster.
   -output string
-    	File to save the output to (default "runai-preinstall-diagnostics.txt")
+    	File to save the output to (default "runai-diagnostics.txt")
   -registry string
     	URL to container image registry to check connectivity to (default "https://gcr.io/run-ai-prod")
   -saas-address string

--- a/cmd/preinstall-diagnostics/main.go
+++ b/cmd/preinstall-diagnostics/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"flag"
+	"os"
+
 	"github.com/run-ai/preinstall-diagnostics/internal/cmd/cli"
 	"github.com/run-ai/preinstall-diagnostics/internal/cmd/job"
-	"os"
 
 	"github.com/run-ai/preinstall-diagnostics/internal/env"
 	"github.com/run-ai/preinstall-diagnostics/internal/log"
@@ -27,7 +28,7 @@ const (
 )
 
 const (
-	defaultOutputFileName = "runai-preinstall-diagnostics.txt"
+	defaultOutputFileName = "runai-diagnostics.txt"
 )
 
 var (
@@ -55,7 +56,7 @@ func init() {
 	flag.StringVar(&backendDomainFQDN, backendDomainArgName, "", "FQDN of the runai backend to resolve (required for DNS resolve test)")
 	flag.StringVar(&clusterDomainFQDN, clusterDomainArgName, "", "FQDN of the cluster")
 	flag.StringVar(&image, imageArgName, registry.RunAIDiagnosticsImage, "Diagnostics image to use (for air-gapped environments)")
-	flag.StringVar(&imagePullSecretName, imagePullSecretArgName, "", "Secret name (within the 'runai-preinstall-diagnostics' namespace) that contains container-registry credentials")
+	flag.StringVar(&imagePullSecretName, imagePullSecretArgName, "", "Secret name (within the 'runai-diagnostics' namespace) that contains container-registry credentials")
 	flag.BoolVar(&dryRun, dryRunArgName, false, "Print the diagnostics resources without executing")
 	flag.StringVar(&runaiContainerRegistry, runaiContainerRegistryArgName, registry.RunAIProdRegistryURL, "URL to container image registry to check connectivity to")
 	flag.StringVar(&runaiSaas, runaiSaasArgName, saas.RunAISaasAddress, "URL the Run:AI service to check connectivity to")

--- a/internal/cmd/cli/cli.go
+++ b/internal/cmd/cli/cli.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"time"
+
 	"github.com/jedib0t/go-pretty/v6/table"
 	v2 "github.com/run-ai/preinstall-diagnostics/internal"
 	"github.com/run-ai/preinstall-diagnostics/internal/k8sclient"
@@ -15,8 +18,6 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/azure"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
-	"os"
-	"time"
 )
 
 func Main(clean, dryRun bool, backendFQDN, clusterFQDN, image, imagePullSecretName, imageRegistry,
@@ -115,8 +116,8 @@ func getNodesTestsResultsTables() ([]NodeResult, error) {
 	}
 
 	for _, node := range nodeList.Items {
-		cm, err := k8s.CoreV1().ConfigMaps("runai-preinstall-diagnostics").
-			Get(context.TODO(), "runai-preinstall-diagnostics-"+node.Name, metav1.GetOptions{})
+		cm, err := k8s.CoreV1().ConfigMaps("runai-diagnostics").
+			Get(context.TODO(), "runai-diagnostics-"+node.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cmd/job/job.go
+++ b/internal/cmd/job/job.go
@@ -3,6 +3,7 @@ package job
 import (
 	"context"
 	"encoding/json"
+
 	v2 "github.com/run-ai/preinstall-diagnostics/internal"
 	"github.com/run-ai/preinstall-diagnostics/internal/env"
 	"github.com/run-ai/preinstall-diagnostics/internal/k8sclient"
@@ -34,7 +35,7 @@ func deleteConfigMapIfExists() error {
 	}
 
 	err = k8s.CoreV1().ConfigMaps(resources.Namespace.Name).Delete(context.TODO(),
-		"runai-preinstall-diagnostics-"+env.EnvOrDefault("NODE_NAME", ""),
+		"runai-diagnostics-"+env.EnvOrDefault("NODE_NAME", ""),
 		metav1.DeleteOptions{})
 	if err != nil && !errors.IsNotFound(err) {
 		return err
@@ -56,7 +57,7 @@ func createConfigMapWithTestResults(results []v2.TestResult) error {
 
 	cm := v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "runai-preinstall-diagnostics-" + env.EnvOrDefault("NODE_NAME", ""),
+			Name:      "runai-diagnostics-" + env.EnvOrDefault("NODE_NAME", ""),
 			Namespace: resources.Namespace.Name,
 		},
 		Data: map[string]string{

--- a/internal/internal-cluster-tests/nodes.go
+++ b/internal/internal-cluster-tests/nodes.go
@@ -4,19 +4,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/run-ai/preinstall-diagnostics/internal/env"
-	"github.com/run-ai/preinstall-diagnostics/internal/k8sclient"
-	"github.com/run-ai/preinstall-diagnostics/internal/log"
-	"github.com/run-ai/preinstall-diagnostics/internal/resources"
 	"io"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/kubernetes"
 	"net/http"
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/run-ai/preinstall-diagnostics/internal/env"
+	"github.com/run-ai/preinstall-diagnostics/internal/k8sclient"
+	"github.com/run-ai/preinstall-diagnostics/internal/log"
+	"github.com/run-ai/preinstall-diagnostics/internal/resources"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -103,7 +104,7 @@ func WaitForJobPodsToBeRunning(logger *log.Logger) error {
 	for podAvailabilityAttempts > 0 {
 		logger.LogF("waiting for jobs to be available...")
 
-		jobs, err := k8s.BatchV1().Jobs("runai-preinstall-diagnostics").List(context.TODO(), metav1.ListOptions{})
+		jobs, err := k8s.BatchV1().Jobs("runai-diagnostics").List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -127,7 +128,7 @@ func WaitForJobPodsToBeRunning(logger *log.Logger) error {
 
 func GetJobsPods(client *kubernetes.Clientset) ([]v1.Pod, error) {
 	labelSelector := strings.ReplaceAll(labels.FormatLabels(map[string]string{
-		"runai-preinstall-diagnostics": "",
+		"runai-diagnostics": "",
 	}), "=", "")
 	pods, err := client.CoreV1().Pods(resources.Namespace.Name).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: labelSelector,

--- a/internal/resources/defaults.go
+++ b/internal/resources/defaults.go
@@ -3,7 +3,7 @@ package resources
 import "github.com/run-ai/preinstall-diagnostics/internal/registry"
 
 const (
-	defaultResourceName = "runai-preinstall-diagnostics"
+	defaultResourceName = "runai-diagnostics"
 
 	rbacAPIGroup   = "rbac.authorization.k8s.io"
 	rbacAPIVersion = "v1"

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -3,15 +3,16 @@ package utils
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"time"
+
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/run-ai/preinstall-diagnostics/internal/k8sclient"
 	"github.com/run-ai/preinstall-diagnostics/internal/log"
 	"github.com/run-ai/preinstall-diagnostics/internal/resources"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
-	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 )
 
 func CheckURLAvailable(url string) (bool, error) {
@@ -36,7 +37,7 @@ func WaitForJobsToComplete(interval, timeout time.Duration) error {
 	for ; timeout > 0; timeout -= interval {
 		time.Sleep(interval)
 
-		jobs, err := k8s.BatchV1().Jobs("runai-preinstall-diagnostics").List(context.TODO(),
+		jobs, err := k8s.BatchV1().Jobs("runai-diagnostics").List(context.TODO(),
 			metav1.ListOptions{})
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes #28 by abbreviating all `runai-preinstall-diagnostics` prefixes to `runai-diagnostics`. These resources are cleaned up by the tool anyway so the absence of `preinstall` in the resource name does not impact any functionality. 